### PR TITLE
Add OTP rate limiter functionality

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,6 +1,11 @@
 const express = require("express");
+
+//import rate limiter
+//const otpLimiter = require("./middlewares/rateLimiter");
+
 const userRoute = require("./routes/userRoute");
 const authRoute = require("./routes/authRoute");
+const otpLimiter = require("./middlewares/rateLimiter");
 const dummyRoute = require("./routes/dummyRoute");
 const dotenv = require("dotenv");
 const cookieParser = require("cookie-parser");
@@ -47,7 +52,9 @@ app.use((req, res, next) => {
 });
 
 // Routes
+
 app.use(`${API_PREFIX}/user`, userRoute);
+//app.use(`${API_PREFIX}/authentication`, otpLimiter, authRoute); // Rate limiter added here
 app.use(`${API_PREFIX}/authentication`, authRoute);
 app.use(`${API_PREFIX}/group`, groupRoute);
 app.use(`${API_PREFIX}/dummy`, dummyRoute);

--- a/middlewares/rateLimiter.js
+++ b/middlewares/rateLimiter.js
@@ -1,3 +1,4 @@
+/*
 const rateLimit = require("express-rate-limit");
 
 const otpLimiter = rateLimit({
@@ -7,3 +8,51 @@ const otpLimiter = rateLimit({
 });
 
 module.exports = { otpLimiter };
+*/
+
+
+
+const rateLimit = require("express-rate-limit");
+
+// Rate limiter for OTP requests: 1 request per minute
+const otpLimiter = rateLimit({
+  windowMs: 60 * 1000, // 1 minute
+  max: 1, // Limit each IP to 1 request per windowMs
+  message: "Too many requests, please try again after a minute.", // Custom error message
+  standardHeaders: true, // Includes rate limit info in headers
+  legacyHeaders: false, // Disables legacy X-RateLimit-* headers
+});
+
+module.exports = otpLimiter;
+
+
+/*
+const rateLimit = require("express-rate-limit");
+const { MemoryStore } = require("express-rate-limit");
+
+// Rate limiter based on user ID with a custom error message
+const otpLimiter = rateLimit({
+  windowMs: 60 * 1000, // 1 minute
+  max: 1, // Limit each user to 1 request per minute
+  keyGenerator: (req) => {
+    // Ensure req.user is defined
+    if (!req.user || !req.user.id) {
+      throw new Error("User not authenticated. Rate limiting requires authentication.");
+    }
+    return req.user.id; // Use user ID for rate-limiting key
+  },
+  handler: (req, res) => {
+    res.status(429).json({ message: "Only one OTP request per minute is allowed." });
+  },
+  store: new MemoryStore(), // Store rate limits in memory
+});
+
+module.exports = otpLimiter;
+*/
+
+
+
+
+
+
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "cors": "^2.8.5",
         "dotenv": "^16.4.5",
         "express": "^4.19.2",
+        "express-rate-limit": "^7.4.1",
         "express-rate-limiter": "^1.3.1",
         "express-session": "^1.18.0",
         "faker": "^5.5.3",
@@ -2002,6 +2003,20 @@
       },
       "engines": {
         "node": ">= 0.10.0"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-7.4.1.tgz",
+      "integrity": "sha512-KS3efpnpIDVIXopMc65EMbWbUht7qvTCdtCR2dD/IZmi9MIkopYESwyRqLgv8Pfu589+KqDqOdzJWW7AHoACeg==",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": "4 || 5 || ^5.0.0-beta.1"
       }
     },
     "node_modules/express-rate-limiter": {
@@ -6738,6 +6753,12 @@
         "vary": "~1.1.2"
       }
     },
+    "express-rate-limit": {
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-7.4.1.tgz",
+      "integrity": "sha512-KS3efpnpIDVIXopMc65EMbWbUht7qvTCdtCR2dD/IZmi9MIkopYESwyRqLgv8Pfu589+KqDqOdzJWW7AHoACeg==",
+      "requires": {}
+    },
     "express-rate-limiter": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/express-rate-limiter/-/express-rate-limiter-1.3.1.tgz",
@@ -7870,6 +7891,7 @@
         "dotenv": "^16.4.5",
         "eslint": "^8.52.0",
         "express": "^4.19.2",
+        "express-rate-limit": "^7.4.1",
         "express-rate-limiter": "^1.3.1",
         "express-session": "^1.18.0",
         "faker": "^5.5.3",
@@ -9249,6 +9271,12 @@
             "utils-merge": "1.0.1",
             "vary": "~1.1.2"
           }
+        },
+        "express-rate-limit": {
+          "version": "7.4.1",
+          "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-7.4.1.tgz",
+          "integrity": "sha512-KS3efpnpIDVIXopMc65EMbWbUht7qvTCdtCR2dD/IZmi9MIkopYESwyRqLgv8Pfu589+KqDqOdzJWW7AHoACeg==",
+          "requires": {}
         },
         "express-rate-limiter": {
           "version": "1.3.1",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "cors": "^2.8.5",
     "dotenv": "^16.4.5",
     "express": "^4.19.2",
+    "express-rate-limit": "^7.4.1",
     "express-rate-limiter": "^1.3.1",
     "express-session": "^1.18.0",
     "faker": "^5.5.3",

--- a/routes/authRoute.js
+++ b/routes/authRoute.js
@@ -1,4 +1,5 @@
 const express = require("express");
+const otpLimiter = require("../middlewares/rateLimiter");
 const { isAuthenticated } = require("../middlewares/auth");
 const router = express.Router();
 const {
@@ -17,7 +18,9 @@ router.route("/login").post(loginUser);
 router.route("/register").post(registerUser);
 router.route("/logout").get(isAuthenticated, logoutUser);
 
-router.route("/send-otp").post(sendOTP);
+//router.route("/send-otp").post(sendOTP);
+router.route("/send-otp").post(otpLimiter, sendOTP); // Apply rate limiter only to this route
+
 router.route("/verify-otp").post(verifyOTP);
 router.route("/forgot-password").post(forgotPassword);
 


### PR DESCRIPTION
Implemented OTP rate limiting for API endpoint to prevent DoS attacks.

- Added rate-limiting middleware
- Configured max requests per minute

